### PR TITLE
Conditional secrets

### DIFF
--- a/3.0.43.1/templates/admission-controller-secret.yaml
+++ b/3.0.43.1/templates/admission-controller-secret.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.config.admissionControl.createService }}
+{{ if eq .Values.config.admissionControl.createSecret true}}
 apiVersion: v1
 kind: Secret
 data:
@@ -14,4 +15,5 @@ metadata:
   name: admission-control-tls
   namespace: stackrox
 type: Opaque
+{{ end }}
 {{ end }}

--- a/3.0.43.1/templates/admission-controller-secret.yaml
+++ b/3.0.43.1/templates/admission-controller-secret.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.config.admissionControl.createService }}
-{{ if eq .Values.config.admissionControl.createSecret true}}
+{{ if and .Values.config.admissionControl.createService (eq .Values.config.admissionControl.createSecret true) }}
 apiVersion: v1
 kind: Secret
 data:
@@ -15,5 +14,4 @@ metadata:
   name: admission-control-tls
   namespace: stackrox
 type: Opaque
-{{ end }}
 {{ end }}

--- a/3.0.43.1/templates/collector-secret.yaml
+++ b/3.0.43.1/templates/collector-secret.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.config.collector.createSecret true}}
 apiVersion: v1
 kind: Secret
 data:
@@ -13,3 +14,4 @@ metadata:
   name: collector-tls
   namespace: stackrox
 type: Opaque
+{{ end }}

--- a/3.0.43.1/templates/sensor-secret.yaml
+++ b/3.0.43.1/templates/sensor-secret.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.config.sensor.createSecret true}}
 apiVersion: v1
 kind: Secret
 data:
@@ -13,3 +14,4 @@ metadata:
   name: sensor-tls
   namespace: stackrox
 type: Opaque
+{{ end }}

--- a/3.0.43.1/values.yaml
+++ b/3.0.43.1/values.yaml
@@ -18,16 +18,19 @@ config:
   collectionMethod: KERNEL_MODULE
   admissionControl:
     createService: false
+    createSecret: true
     listenOnUpdates: false
     enableService: false
     enforceOnUpdates: false
     scanInline: false
     disableBypass: false
     timeout: 3
+  collector:
+    createSecret: true
+  sensor:
+    createSecret: true
   registryOverride:
   disableTaintTolerations: true
   createUpgraderServiceAccount: false
 
 envVars:  []
-  
-


### PR DESCRIPTION
admission controller | collector | sensor conditional secrets.
default is `true` to create the secrets
optionally, consumers can set to `false` which will not create secrets, or clobber existing secrets
