### PR TITLE
chore(deps): bump actions/checkout to v4

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -8,7 +8,7 @@ jobs:
   README_UPDATE:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
       - name: Updating README


### PR DESCRIPTION
IMHO Dependabot is not required in this repository. 
Apart from this one workflow with one updatable dependency, it is only static content.  